### PR TITLE
Referencing fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ issues:
         - forcetypeassert
         - funlen
         - goerr113
+        - dupl
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: fmt lint test
 
 .PHONY: test
 test:
-	go test $(GOTEST_FLAGS) -race ./... -tags !wasm
+	go test $(GOTEST_FLAGS) -race ./...
 
 .PHONY: lint
 lint:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bufbuild/buf v1.29.0
 	github.com/conduitio/conduit-commons v0.0.0-20240103200651-5a5746611a8e
 	github.com/golangci/golangci-lint v1.55.2
+	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.31.0
 	go.uber.org/mock v0.4.0
 	google.golang.org/protobuf v1.32.0

--- a/internal/reference/errors.go
+++ b/internal/reference/errors.go
@@ -1,0 +1,31 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import "fmt"
+
+type UnexpectedTokenError struct {
+	i item
+}
+
+func (e UnexpectedTokenError) Error() string {
+	return fmt.Sprintf("unexpected token %s", e.i)
+}
+
+var (
+	ErrImmutableReference = fmt.Errorf("cannot set immutable reference")
+	ErrNotResolvable      = fmt.Errorf("cannot resolve reference")
+	ErrUnexpectedType     = fmt.Errorf("unexpected type")
+)

--- a/internal/reference/lexer.go
+++ b/internal/reference/lexer.go
@@ -16,7 +16,6 @@ package reference
 
 import (
 	"fmt"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -120,27 +119,6 @@ func (l *lexer) emit(t itemType) stateFn {
 func (l *lexer) emitItem(i item) stateFn {
 	l.item = i
 	return nil
-}
-
-// ignore skips over the pending input before this point.
-func (l *lexer) ignore() {
-	l.start = l.pos
-}
-
-// accept consumes the next rune if it's from the valid set.
-func (l *lexer) accept(valid string) bool {
-	if strings.ContainsRune(valid, l.next()) {
-		return true
-	}
-	l.backup()
-	return false
-}
-
-// acceptRun consumes a run of runes from the valid set.
-func (l *lexer) acceptRun(valid string) {
-	for strings.ContainsRune(valid, l.next()) {
-	}
-	l.backup()
 }
 
 // errorf returns an error token and terminates the scan by passing

--- a/internal/reference/lexer.go
+++ b/internal/reference/lexer.go
@@ -25,6 +25,8 @@ import (
 // template action delimiters (e.g. {{ or }}), only field references. It also
 // does not support the "pipeline" syntax (e.g. .X.Y | func) or any of the
 // other template features.
+// However, it additionally supports accessing map values using the standard
+// bracket notation (e.g. .X["Y"]).
 type lexer struct {
 	input string
 	pos   int  // current position in the input

--- a/internal/reference/lexer.go
+++ b/internal/reference/lexer.go
@@ -1,0 +1,236 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// lexer is a subset of the text/template lexer. It does not expect to see any
+// template action delimiters (e.g. {{ or }}), only field references. It also
+// does not support the "pipeline" syntax (e.g. .X.Y | func) or any of the
+// other template features.
+type lexer struct {
+	input string
+	pos   int  // current position in the input
+	start int  // start position of this item
+	item  item // item to return to parser
+	atEOF bool // we have hit the end of input and returned eof
+}
+
+type item struct {
+	typ itemType
+	pos int
+	val string
+}
+
+func (i item) String() string {
+	switch {
+	case i.typ == itemEOF:
+		return "EOF"
+	case i.typ == itemError:
+		return i.val
+	case len(i.val) > 10:
+		return fmt.Sprintf("%.10q...", i.val)
+	}
+	return fmt.Sprintf("%q", i.val)
+}
+
+type itemType int
+
+// stateFn represents the state of the scanner as a function that returns the next state.
+type stateFn func(*lexer) stateFn
+
+const (
+	itemError itemType = iota
+	itemEOF
+	itemDot
+	itemField
+	itemVariable // variable starting with '$', such as '$' or  '$1' or '$hello'
+)
+
+const eof = -1
+
+func newLexer(input string) *lexer {
+	return &lexer{
+		input: input,
+	}
+}
+
+// next returns the next rune in the input.
+func (l *lexer) next() rune {
+	if l.pos >= len(l.input) {
+		l.atEOF = true
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += w
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (l *lexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+// backup steps back one rune.
+func (l *lexer) backup() {
+	if !l.atEOF && l.pos > 0 {
+		_, w := utf8.DecodeLastRuneInString(l.input[:l.pos])
+		l.pos -= w
+	}
+}
+
+// thisItem returns the item at the current input point with the specified type
+// and advances the input.
+func (l *lexer) thisItem(t itemType) item {
+	i := item{t, l.start, l.input[l.start:l.pos]}
+	l.start = l.pos
+	return i
+}
+
+// emit passes the trailing text as an item back to the parser.
+func (l *lexer) emit(t itemType) stateFn {
+	return l.emitItem(l.thisItem(t))
+}
+
+// emitItem passes the specified item to the parser.
+func (l *lexer) emitItem(i item) stateFn {
+	l.item = i
+	return nil
+}
+
+// ignore skips over the pending input before this point.
+func (l *lexer) ignore() {
+	l.start = l.pos
+}
+
+// accept consumes the next rune if it's from the valid set.
+func (l *lexer) accept(valid string) bool {
+	if strings.ContainsRune(valid, l.next()) {
+		return true
+	}
+	l.backup()
+	return false
+}
+
+// acceptRun consumes a run of runes from the valid set.
+func (l *lexer) acceptRun(valid string) {
+	for strings.ContainsRune(valid, l.next()) {
+	}
+	l.backup()
+}
+
+// errorf returns an error token and terminates the scan by passing
+// back a nil pointer that will be the next state, terminating l.nextItem.
+func (l *lexer) errorf(format string, args ...any) stateFn {
+	l.item = item{itemError, l.start, fmt.Sprintf(format, args...)}
+	l.start = 0
+	l.pos = 0
+	l.input = l.input[:0]
+	return nil
+}
+
+// atTerminator reports whether the input is at valid termination character to
+// appear after an identifier. Breaks .X.Y into two pieces.
+func (l *lexer) atTerminator() bool {
+	r := l.peek()
+	if l.isSpace(r) {
+		return true
+	}
+	switch r {
+	case eof, '.':
+		return true
+	}
+	return false
+}
+
+// isSpace reports whether r is a space character.
+func (*lexer) isSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\r' || r == '\n'
+}
+
+// isAlphaNumeric reports whether r is an alphabetic, digit, or underscore.
+func (*lexer) isAlphaNumeric(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+func (l *lexer) Next() item {
+	l.item = item{itemEOF, l.pos, "EOF"}
+	state := (*lexer).lexReference
+	for {
+		state = state(l)
+		if state == nil {
+			return l.item
+		}
+	}
+}
+
+// lexReference scans a reference: .Alphanumeric or $.Alphanumeric.
+func (l *lexer) lexReference() stateFn {
+	switch r := l.next(); {
+	case r == eof:
+		return l.emit(itemEOF)
+	case r == '$':
+		return (*lexer).lexVariable
+	case r == '.':
+		// special look-ahead for ".field" so we don't break l.backup().
+		if l.pos < len(l.input) {
+			r := l.input[l.pos]
+			if r >= '0' && r <= '9' {
+				return l.errorf("unrecognized character at the start of a field name: %#U", r)
+			}
+		}
+		return (*lexer).lexField
+	default:
+		return l.errorf("unrecognized character in reference: %#U", r)
+	}
+}
+
+// lexVariable scans a Variable: $Alphanumeric.
+// The $ has been scanned.
+func (l *lexer) lexVariable() stateFn {
+	if l.atTerminator() { // Nothing interesting follows -> "$".
+		return l.emit(itemVariable)
+	}
+	// We do not allow named variables, you can just access fields inside the
+	// root variable.
+	return l.errorf("bad character %#U", l.peek())
+}
+
+// lexField scans a field: .Alphanumeric.
+// The . has been scanned.
+func (l *lexer) lexField() stateFn {
+	if l.atTerminator() { // Nothing interesting follows -> ".".
+		return l.emit(itemDot)
+	}
+	var r rune
+	for {
+		r = l.next()
+		if !l.isAlphaNumeric(r) {
+			l.backup()
+			break
+		}
+	}
+	if !l.atTerminator() {
+		return l.errorf("bad character %#U", r)
+	}
+	return l.emit(itemField)
+}

--- a/internal/reference/lexer_test.go
+++ b/internal/reference/lexer_test.go
@@ -1,0 +1,97 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func mkItem(typ itemType, text string) item {
+	return item{
+		typ: typ,
+		val: text,
+	}
+}
+
+func assertEqual(t *testing.T, i1, i2 []item, checkPos bool) bool {
+	is := is.New(t)
+	is.Helper()
+	is.Equal(len(i1), len(i2))
+
+	for k := range i1 {
+		is.Equal(i1[k].typ, i2[k].typ)
+		is.Equal(i1[k].val, i2[k].val)
+		if checkPos {
+			is.Equal(i1[k].pos, i2[k].pos)
+		}
+	}
+	return true
+}
+
+func TestLex(t *testing.T) {
+	var testCases = []struct {
+		name  string
+		input string
+		items []item
+	}{
+		{"empty", "", []item{
+			mkItem(itemEOF, ""),
+		}},
+		{"dot", ".", []item{
+			mkItem(itemDot, "."),
+			mkItem(itemEOF, ""),
+		}},
+		{"fields", ".x.y.z", []item{
+			mkItem(itemField, ".x"),
+			mkItem(itemField, ".y"),
+			mkItem(itemField, ".z"),
+			mkItem(itemEOF, ""),
+		}},
+		{"variable", "$.x", []item{
+			mkItem(itemVariable, "$"),
+			mkItem(itemField, ".x"),
+			mkItem(itemEOF, ""),
+		}},
+		{"named variable", "$x", []item{
+			mkItem(itemError, "bad character U+0078 'x'"),
+		}},
+		{"space", " ", []item{
+			mkItem(itemError, "unrecognized character in reference: U+0020 ' '"),
+		}},
+		{"filed starting with number", ".0abc", []item{
+			mkItem(itemError, "unrecognized character at the start of a field name: U+0030 '0'"),
+		}},
+		{"parentheses", "(.x)", []item{
+			mkItem(itemError, "unrecognized character in reference: U+0028 '('"),
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := newLexer(tc.input)
+			var items []item
+			for {
+				item := l.Next()
+				items = append(items, item)
+				if item.typ == itemEOF || item.typ == itemError {
+					break
+				}
+			}
+			assertEqual(t, items, tc.items, false)
+		})
+	}
+}

--- a/internal/reference/lexer_test.go
+++ b/internal/reference/lexer_test.go
@@ -43,7 +43,7 @@ func assertEqual(t *testing.T, i1, i2 []item, checkPos bool) bool {
 }
 
 func TestLex(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name  string
 		input string
 		items []item

--- a/internal/reference/lexer_test.go
+++ b/internal/reference/lexer_test.go
@@ -28,6 +28,7 @@ func mkItem(typ itemType, text string) item {
 }
 
 func assertEqual(t *testing.T, i1, i2 []item, checkPos bool) bool {
+	t.Helper()
 	is := is.New(t)
 	is.Helper()
 	is.Equal(len(i1), len(i2))

--- a/internal/reference/lexer_test.go
+++ b/internal/reference/lexer_test.go
@@ -66,6 +66,13 @@ func TestLex(t *testing.T) {
 			mkItem(itemField, ".x"),
 			mkItem(itemEOF, ""),
 		}},
+		{"map index", `.x["my string"]`, []item{
+			mkItem(itemField, ".x"),
+			mkItem(itemLeftBracket, "["),
+			mkItem(itemString, `"my string"`),
+			mkItem(itemRightBracket, "]"),
+			mkItem(itemEOF, ""),
+		}},
 		{"named variable", "$x", []item{
 			mkItem(itemError, "bad character U+0078 'x'"),
 		}},

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -165,11 +165,11 @@ func (r positionReference) Get() any {
 }
 
 func (r positionReference) Set(any) error {
-	return fmt.Errorf("cannot set position: %w", ErrImmutableReference)
+	return fmt.Errorf("cannot set .Position: %w", ErrImmutableReference)
 }
 
 func (r positionReference) Delete() error {
-	return fmt.Errorf("cannot delete position: %w", ErrImmutableReference)
+	return fmt.Errorf("cannot delete .Position: %w", ErrImmutableReference)
 }
 
 func (r positionReference) walk(string) (Reference, error) {
@@ -195,10 +195,10 @@ func (r operationReference) Set(val any) error {
 	case string:
 		err := op.UnmarshalText([]byte(val))
 		if err != nil {
-			return fmt.Errorf("failed to set operation: %w", err)
+			return fmt.Errorf("failed to set .Operation: %w", err)
 		}
 	default:
-		return fmt.Errorf("can't set type %T for operation: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Operation: %w", val, ErrUnexpectedType)
 	}
 
 	if op < opencdc.OperationCreate || op > opencdc.OperationSnapshot {
@@ -214,7 +214,7 @@ func (r operationReference) Delete() error {
 }
 
 func (r operationReference) walk(string) (Reference, error) {
-	return nil, fmt.Errorf("operation is not a structured field: %w", ErrNotResolvable)
+	return nil, fmt.Errorf(".Operation is not a structured field: %w", ErrNotResolvable)
 }
 
 type metadataReference struct {
@@ -234,7 +234,7 @@ func (r metadataReference) Set(val any) error {
 	case nil:
 		r.rec.Metadata = opencdc.Metadata{} // reset metadata
 	default:
-		return fmt.Errorf("can't set type %T for metadata: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Metadata: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -273,7 +273,7 @@ func (r metadataFieldReference) Set(val any) error {
 	case nil:
 		delete(r.rec.Metadata, r.field) // delete field
 	default:
-		return fmt.Errorf("can't set type %T for metadata: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Metadata: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -284,7 +284,7 @@ func (r metadataFieldReference) Delete() error {
 }
 
 func (r metadataFieldReference) walk(string) (Reference, error) {
-	return nil, fmt.Errorf("metadata fields are not structured: %w", ErrNotResolvable)
+	return nil, fmt.Errorf(".Metadata fields are not structured: %w", ErrNotResolvable)
 }
 
 type keyReference struct {
@@ -308,7 +308,7 @@ func (r keyReference) Set(val any) error {
 	case nil:
 		r.rec.Key = nil
 	default:
-		return fmt.Errorf("can't set type %T for key: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Key: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -326,11 +326,12 @@ func (r keyReference) walk(field string) (Reference, error) {
 		// create new structured data
 		r.rec.Key = opencdc.StructuredData{}
 	default:
-		return nil, fmt.Errorf("key does not contain structured data: %w", ErrNotResolvable)
+		return nil, fmt.Errorf(".Key does not contain structured data: %w", ErrNotResolvable)
 	}
 	return dataFieldReference{
 		data:  r.rec.Key.(opencdc.StructuredData), //nolint:forcetypeassert // we know it's the right type
 		field: field,
+		path:  ".Key",
 	}, nil
 }
 
@@ -347,7 +348,7 @@ func (r payloadReference) Set(val any) error {
 	case opencdc.Change:
 		r.rec.Payload = val
 	default:
-		return fmt.Errorf("can't set type %T for payload: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Payload: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -389,7 +390,7 @@ func (r payloadBeforeReference) Set(val any) error {
 	case nil:
 		r.rec.Payload.Before = nil
 	default:
-		return fmt.Errorf("can't set type %T for payload before: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Payload.Before: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -407,11 +408,12 @@ func (r payloadBeforeReference) walk(field string) (Reference, error) {
 		// create new structured data
 		r.rec.Payload.Before = opencdc.StructuredData{}
 	default:
-		return nil, fmt.Errorf("payload before does not contain structured data: %w", ErrNotResolvable)
+		return nil, fmt.Errorf(".Payload.Before does not contain structured data: %w", ErrNotResolvable)
 	}
 	return dataFieldReference{
 		data:  r.rec.Payload.Before.(opencdc.StructuredData), //nolint:forcetypeassert // we know it's the right type
 		field: field,
+		path:  ".Payload.Before",
 	}, nil
 }
 
@@ -436,7 +438,7 @@ func (r payloadAfterReference) Set(val any) error {
 	case nil:
 		r.rec.Payload.After = nil
 	default:
-		return fmt.Errorf("can't set type %T for payload after: %w", val, ErrUnexpectedType)
+		return fmt.Errorf("can't set type %T for .Payload.After: %w", val, ErrUnexpectedType)
 	}
 	return nil
 }
@@ -454,17 +456,19 @@ func (r payloadAfterReference) walk(field string) (Reference, error) {
 		// create new structured data
 		r.rec.Payload.After = opencdc.StructuredData{}
 	default:
-		return nil, fmt.Errorf("payload after does not contain structured data: %w", ErrNotResolvable)
+		return nil, fmt.Errorf(".Payload.After does not contain structured data: %w", ErrNotResolvable)
 	}
 	return dataFieldReference{
 		data:  r.rec.Payload.After.(opencdc.StructuredData), //nolint:forcetypeassert // we know it's the right type
 		field: field,
+		path:  ".Payload.After",
 	}, nil
 }
 
 type dataFieldReference struct {
 	data  map[string]any
 	field string
+	path  string
 }
 
 func (r dataFieldReference) Get() any {
@@ -489,7 +493,11 @@ func (r dataFieldReference) walk(field string) (Reference, error) {
 
 	data, ok := r.data[r.field].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("data field %s does not contain structured data: %w", r.field, ErrNotResolvable)
+		return nil, fmt.Errorf("%s.%s does not contain structured data: %w", r.path, r.field, ErrNotResolvable)
 	}
-	return dataFieldReference{data: data, field: field}, nil
+	return dataFieldReference{
+		data:  data,
+		field: field,
+		path:  r.path + "." + r.field,
+	}, nil
 }

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -1,0 +1,173 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+)
+
+type Reference struct {
+	val reflect.Value
+}
+
+func (r Reference) Get() any {
+	return r.val.Interface()
+}
+
+func (r Reference) Set(val string) error {
+	switch r.val.Kind() {
+	case reflect.String:
+		r.val.SetString(val)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, err := strconv.ParseInt(val, 10, r.val.Type().Bits())
+		if err != nil {
+			return err
+		}
+		r.val.SetInt(i)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		i, err := strconv.ParseUint(val, 10, r.val.Type().Bits())
+		if err != nil {
+			return err
+		}
+		r.val.SetUint(i)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(val, r.val.Type().Bits())
+		if err != nil {
+			return err
+		}
+		r.val.SetFloat(f)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+		r.val.SetBool(b)
+	case reflect.Map:
+		// TODO support map
+		fallthrough
+	case reflect.Slice:
+		if r.val.Type().Elem().Kind() == reflect.Uint8 {
+			r.val.SetBytes([]byte(val))
+			return nil
+		}
+		fallthrough
+	default:
+		return fmt.Errorf("unsupported type %s", r.val.Type())
+	}
+	return nil
+}
+
+// ReferenceResolver is a type that knows how to resolve a reference to a field
+// in a record. It is used to specify the target of a processor's output.
+type ReferenceResolver struct {
+	// Raw is the raw string that was parsed to create this reference resolver.
+	Raw string
+
+	walker referenceWalker
+}
+
+func NewReferenceResolver(ref string) (ReferenceResolver, error) {
+	l := newLexer(ref)
+
+	i := l.Next()
+	if i.typ == itemVariable {
+		// skip variable token, if any
+		i = l.Next()
+	}
+
+	var walkers []referenceWalker
+	for i.typ != itemEOF && i.typ != itemError {
+		// for now all we accept are chained fields
+		if i.typ != itemField {
+			return ReferenceResolver{}, fmt.Errorf("invalid reference %q: unexpected token %s", ref, i)
+		}
+		field := i.val[1:] // skip leading dot
+		walkers = append(walkers, fieldReferenceWalker{field: field})
+		i = l.Next()
+	}
+	if i.typ == itemError {
+		return ReferenceResolver{}, fmt.Errorf("invalid reference %q: %s", ref, i.val)
+	}
+
+	return ReferenceResolver{
+		Raw:    ref,
+		walker: chainedReferenceWalker(walkers),
+	}, nil
+}
+
+// Resolve resolves the reference to a field in the record. If the reference
+// cannot be resolved an error is returned. If the reference is valid but the
+// field does not exist in the record, the field will be created.
+// The returned reference can be used to set the value of the field.
+func (rr ReferenceResolver) Resolve(rec *opencdc.Record) (Reference, error) {
+	recVal := reflect.ValueOf(rec)
+	val, err := rr.walker.walk(recVal)
+	if err != nil {
+		return Reference{}, err
+	}
+	return Reference{val: val}, nil
+}
+
+type referenceWalker interface {
+	walk(val reflect.Value) (reflect.Value, error)
+}
+
+// chainedReferenceWalker is a referenceWalker that chains multiple
+// referenceWalkers together.
+type chainedReferenceWalker []referenceWalker
+
+func (rw chainedReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
+	var err error
+	for _, w := range rw {
+		val, err = w.walk(val)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+	}
+	return val, nil
+}
+
+type fieldReferenceWalker struct {
+	field string
+}
+
+func (rw fieldReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
+	if val.Kind() == reflect.Ptr {
+		// dereference pointer
+		val = val.Elem()
+	}
+
+	switch val.Kind() {
+	case reflect.Struct:
+		fieldVal := val.FieldByName(rw.field)
+		if !fieldVal.IsValid() {
+			return reflect.Value{}, fmt.Errorf("field %q does not exist in struct %s", rw.field, val.Type())
+		}
+		return fieldVal, nil
+	case reflect.Map:
+		v := val.MapIndex(reflect.ValueOf(rw.field))
+		if !v.IsValid() {
+			// TODO create map entry
+			return reflect.Value{}, fmt.Errorf("field %q does not exist in map %s", rw.field, val.Type())
+		}
+		return v, nil
+	default:
+		return reflect.Value{}, fmt.Errorf("unexpected value kind, got %s", val.Kind())
+	}
+}

--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -15,63 +15,80 @@
 package reference
 
 import (
+	"errors"
 	"fmt"
-	"reflect"
-	"strconv"
 
 	"github.com/conduitio/conduit-commons/opencdc"
 )
 
-type Reference struct {
-	val reflect.Value
+type Reference interface {
+	Get() any
+	Set(string) error
+
+	walk(field string) (Reference, error)
 }
 
-func (r Reference) Get() any {
-	return r.val.Interface()
-}
-
-func (r Reference) Set(val string) error {
-	switch r.val.Kind() {
-	case reflect.String:
-		r.val.SetString(val)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		i, err := strconv.ParseInt(val, 10, r.val.Type().Bits())
-		if err != nil {
-			return err
-		}
-		r.val.SetInt(i)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		i, err := strconv.ParseUint(val, 10, r.val.Type().Bits())
-		if err != nil {
-			return err
-		}
-		r.val.SetUint(i)
-	case reflect.Float32, reflect.Float64:
-		f, err := strconv.ParseFloat(val, r.val.Type().Bits())
-		if err != nil {
-			return err
-		}
-		r.val.SetFloat(f)
-	case reflect.Bool:
-		b, err := strconv.ParseBool(val)
-		if err != nil {
-			return err
-		}
-		r.val.SetBool(b)
-	case reflect.Map:
-		// TODO support map
-		fallthrough
-	case reflect.Slice:
-		if r.val.Type().Elem().Kind() == reflect.Uint8 {
-			r.val.SetBytes([]byte(val))
-			return nil
-		}
-		fallthrough
-	default:
-		return fmt.Errorf("unsupported type %s", r.val.Type())
-	}
-	return nil
-}
+// type simpleReference struct {
+// 	val reflect.Value
+// }
+//
+// func (r simpleReference) Get() any {
+// 	return r.val.Interface()
+// }
+//
+// func (r simpleReference) Set(val string) error {
+// 	switch r.val.Kind() {
+// 	case reflect.String:
+// 		r.val.SetString(val)
+// 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+// 		i, err := strconv.ParseInt(val, 10, r.val.Type().Bits())
+// 		if err != nil {
+// 			return err
+// 		}
+// 		r.val.SetInt(i)
+// 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+// 		i, err := strconv.ParseUint(val, 10, r.val.Type().Bits())
+// 		if err != nil {
+// 			return err
+// 		}
+// 		r.val.SetUint(i)
+// 	case reflect.Float32, reflect.Float64:
+// 		f, err := strconv.ParseFloat(val, r.val.Type().Bits())
+// 		if err != nil {
+// 			return err
+// 		}
+// 		r.val.SetFloat(f)
+// 	case reflect.Bool:
+// 		b, err := strconv.ParseBool(val)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		r.val.SetBool(b)
+// 	case reflect.Slice:
+// 		if r.val.Type().Elem().Kind() == reflect.Uint8 {
+// 			r.val.SetBytes([]byte(val))
+// 			return nil
+// 		}
+// 		fallthrough
+// 	default:
+// 		return fmt.Errorf("unsupported type %s", r.val.Type())
+// 	}
+// 	return nil
+// }
+//
+// type mapValueReference struct {
+// 	mapVal reflect.Value
+// 	key    string
+// }
+//
+// func (r mapValueReference) Get() any {
+// 	return r.mapVal.MapIndex(reflect.ValueOf(r.key)).Interface()
+// }
+//
+// func (r mapValueReference) Set(val string) error {
+// 	r.mapVal.SetMapIndex(reflect.ValueOf(r.key), reflect.ValueOf(val))
+// 	return nil
+// }
 
 // ReferenceResolver is a type that knows how to resolve a reference to a field
 // in a record. It is used to specify the target of a processor's output.
@@ -79,7 +96,7 @@ type ReferenceResolver struct {
 	// Raw is the raw string that was parsed to create this reference resolver.
 	Raw string
 
-	walker referenceWalker
+	fields []string
 }
 
 func NewReferenceResolver(ref string) (ReferenceResolver, error) {
@@ -91,14 +108,15 @@ func NewReferenceResolver(ref string) (ReferenceResolver, error) {
 		i = l.Next()
 	}
 
-	var walkers []referenceWalker
+	var fields []string
 	for i.typ != itemEOF && i.typ != itemError {
 		// for now all we accept are chained fields
 		if i.typ != itemField {
 			return ReferenceResolver{}, fmt.Errorf("invalid reference %q: unexpected token %s", ref, i)
 		}
+		// TODO validate field name in context of the record
 		field := i.val[1:] // skip leading dot
-		walkers = append(walkers, fieldReferenceWalker{field: field})
+		fields = append(fields, field)
 		i = l.Next()
 	}
 	if i.typ == itemError {
@@ -107,7 +125,7 @@ func NewReferenceResolver(ref string) (ReferenceResolver, error) {
 
 	return ReferenceResolver{
 		Raw:    ref,
-		walker: chainedReferenceWalker(walkers),
+		fields: fields,
 	}, nil
 }
 
@@ -116,58 +134,338 @@ func NewReferenceResolver(ref string) (ReferenceResolver, error) {
 // field does not exist in the record, the field will be created.
 // The returned reference can be used to set the value of the field.
 func (rr ReferenceResolver) Resolve(rec *opencdc.Record) (Reference, error) {
-	recVal := reflect.ValueOf(rec)
-	val, err := rr.walker.walk(recVal)
-	if err != nil {
-		return Reference{}, err
-	}
-	return Reference{val: val}, nil
-}
+	var ref Reference = recordReference{rec: rec}
 
-type referenceWalker interface {
-	walk(val reflect.Value) (reflect.Value, error)
-}
-
-// chainedReferenceWalker is a referenceWalker that chains multiple
-// referenceWalkers together.
-type chainedReferenceWalker []referenceWalker
-
-func (rw chainedReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
-	var err error
-	for _, w := range rw {
-		val, err = w.walk(val)
+	for _, field := range rr.fields {
+		var err error
+		ref, err = ref.walk(field)
 		if err != nil {
-			return reflect.Value{}, err
+			return nil, err
 		}
 	}
-	return val, nil
+
+	return ref, nil
 }
 
-type fieldReferenceWalker struct {
+// type referenceWalker interface {
+// 	walk(val reflect.Value) (reflect.Value, error)
+// }
+//
+// // chainedReferenceWalker is a referenceWalker that chains multiple
+// // referenceWalkers together.
+// type chainedReferenceWalker []referenceWalker
+//
+// func (rw chainedReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
+// 	var err error
+// 	for _, w := range rw {
+// 		val, err = w.walk(val)
+// 		if err != nil {
+// 			return reflect.Value{}, err
+// 		}
+// 	}
+// 	return val, nil
+// }
+//
+// type fieldReferenceWalker struct {
+// 	field string
+// }
+//
+// func (rw fieldReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
+// 	switch val.Kind() {
+// 	case reflect.Struct:
+// 		fieldVal := val.FieldByName(rw.field)
+// 		if !fieldVal.IsValid() {
+// 			return reflect.Value{}, fmt.Errorf("field %q does not exist in struct %s", rw.field, val.Type())
+// 		}
+// 		if (fieldVal.Kind() == reflect.Map || fieldVal.Kind() == reflect.Slice) &&
+// 			fieldVal.IsNil() {
+// 			// create empty value as a placeholder
+// 			switch fieldVal.Kind() {
+// 			case reflect.Map:
+// 				fieldVal.Set(reflect.MakeMap(fieldVal.Type()))
+// 			case reflect.Slice:
+// 				fieldVal.Set(reflect.MakeSlice(fieldVal.Type(), 0, 0))
+// 			}
+// 		}
+// 		return fieldVal, nil
+// 	case reflect.Map:
+// 		v := val.MapIndex(reflect.ValueOf(rw.field))
+// 		if !v.IsValid() {
+// 			// create new element in map as a placeholder
+// 			// TODO if the field is nested, create a map[string]interface{} instead of a string
+// 			v = reflect.New(reflect.TypeOf("")).Elem()
+// 			val.SetMapIndex(reflect.ValueOf(rw.field), v)
+// 		}
+// 		return v, nil
+// 	default:
+// 		return reflect.Value{}, fmt.Errorf("unexpected value kind, got %s", val.Kind())
+// 	}
+// }
+
+// type structFieldWalker struct {
+// 	field string
+// }
+//
+// func (w structFieldWalker) walk(ref Reference) (Reference, error) {
+// 	var val reflect.Value
+// 	switch ref := ref.(type) {
+// 	case simpleReference:
+// 		val = ref.val
+// 	case mapValueReference:
+// 		val = ref.mapVal.MapIndex(reflect.ValueOf(ref.key))
+// 		if !val.IsValid() {
+// 			return nil, fmt.Errorf("can't walk map value for key %s, the value does not exist", ref.key)
+// 		}
+// 	default:
+// 		return nil, fmt.Errorf("unexpected Reference type, got %T", ref)
+// 	}
+//
+// 	if val.Kind() != reflect.Struct {
+// 		return nil, fmt.Errorf("expected struct, got %s", val.Kind())
+// 	}
+//
+// 	fieldVal := val.FieldByName(w.field)
+// 	if !fieldVal.IsValid() {
+// 		return nil, fmt.Errorf("field %q does not exist in struct %s", w.field, val.Type())
+// 	}
+//
+// 	return simpleReference{val: fieldVal}, nil
+// }
+//
+// type mapValueWalker struct {
+// 	key string
+// }
+//
+// func (w mapValueWalker) walk(ref Reference) (Reference, error) {
+// 	var val reflect.Value
+// 	switch ref := ref.(type) {
+// 	case simpleReference:
+// 		val = ref.val
+// 	case mapValueReference:
+// 		val = ref.mapVal.MapIndex(reflect.ValueOf(ref.key))
+// 		if !val.IsValid() {
+// 			// TODO create placeholder map[string]interface{}
+// 		}
+// 	default:
+// 		return nil, fmt.Errorf("unexpected Reference type, got %T", ref)
+// 	}
+//
+// 	if val.Kind() != reflect.Map {
+// 		return nil, fmt.Errorf("expected map, got %s", val.Kind())
+// 	}
+//
+// 	return mapValueReference{mapVal: val, key: w.key}, nil
+// }
+
+type recordReference struct {
+	rec *opencdc.Record
+}
+
+func (r recordReference) Get() any {
+	return *r.rec
+}
+
+func (r recordReference) Set(val string) error {
+	// TODO
+	return errors.New("unimplemented")
+}
+
+func (r recordReference) walk(field string) (Reference, error) {
+	switch field {
+	case "Position":
+		return positionReference{rec: r.rec}, nil
+	case "Operation":
+		return operationReference{rec: r.rec}, nil
+	case "Metadata":
+		return metadataReference{rec: r.rec}, nil
+	case "Key":
+		return keyReference{rec: r.rec}, nil
+	case "Payload":
+		return payloadReference{rec: r.rec}, nil
+	default:
+		return nil, fmt.Errorf("unexpected field %q", field)
+	}
+}
+
+type positionReference struct {
+	rec *opencdc.Record
+}
+
+func (r positionReference) Get() any {
+	return r.rec.Position
+}
+
+func (r positionReference) Set(string) error {
+	return errors.New("cannot set position")
+}
+
+func (r positionReference) walk(string) (Reference, error) {
+	return nil, errors.New("position is not a structured field, can't address a field inside position")
+}
+
+type operationReference struct {
+	rec *opencdc.Record
+}
+
+func (r operationReference) Get() any {
+	return r.rec.Operation
+}
+
+func (r operationReference) Set(val string) error {
+	var op opencdc.Operation
+	err := op.UnmarshalText([]byte(val))
+	if err != nil {
+		return fmt.Errorf("failed to set operation: %w", err)
+	}
+	r.rec.Operation = op
+	return nil
+}
+
+func (r operationReference) walk(string) (Reference, error) {
+	return nil, errors.New("operation is not a structured field, can't address a field inside operation")
+}
+
+type metadataReference struct {
+	rec *opencdc.Record
+}
+
+func (r metadataReference) Get() any {
+	return r.rec.Metadata
+}
+
+func (r metadataReference) Set(val string) error {
+	// TODO
+	return nil
+}
+
+func (r metadataReference) walk(field string) (Reference, error) {
+	return metadataFieldReference{rec: r.rec, field: field}, nil
+}
+
+type metadataFieldReference struct {
+	rec   *opencdc.Record
 	field string
 }
 
-func (rw fieldReferenceWalker) walk(val reflect.Value) (reflect.Value, error) {
-	if val.Kind() == reflect.Ptr {
-		// dereference pointer
-		val = val.Elem()
-	}
+func (r metadataFieldReference) Get() any {
+	return r.rec.Metadata[r.field]
+}
 
-	switch val.Kind() {
-	case reflect.Struct:
-		fieldVal := val.FieldByName(rw.field)
-		if !fieldVal.IsValid() {
-			return reflect.Value{}, fmt.Errorf("field %q does not exist in struct %s", rw.field, val.Type())
-		}
-		return fieldVal, nil
-	case reflect.Map:
-		v := val.MapIndex(reflect.ValueOf(rw.field))
-		if !v.IsValid() {
-			// TODO create map entry
-			return reflect.Value{}, fmt.Errorf("field %q does not exist in map %s", rw.field, val.Type())
-		}
-		return v, nil
-	default:
-		return reflect.Value{}, fmt.Errorf("unexpected value kind, got %s", val.Kind())
+func (r metadataFieldReference) Set(val string) error {
+	r.rec.Metadata[r.field] = val
+	return nil
+}
+
+func (r metadataFieldReference) walk(string) (Reference, error) {
+	return nil, errors.New("metadata fields are not structured, can't address a field inside a metadata field")
+}
+
+type keyReference struct {
+	rec *opencdc.Record
+}
+
+func (r keyReference) Get() any {
+	return r.rec.Key
+}
+
+func (r keyReference) Set(val string) error {
+	r.rec.Key = opencdc.RawData(val)
+	return nil
+}
+
+func (r keyReference) walk(field string) (Reference, error) {
+	data, ok := r.rec.Key.(opencdc.StructuredData)
+	if !ok {
+		return nil, errors.New("key does not contain structured data, can't address a field inside key")
 	}
+	return dataFieldReference{data: data, field: field}, nil
+}
+
+type payloadReference struct {
+	rec *opencdc.Record
+}
+
+func (r payloadReference) Get() any {
+	return r.rec.Payload
+}
+
+func (r payloadReference) Set(val string) error {
+	// TODO
+	return errors.New("not implemented")
+}
+
+func (r payloadReference) walk(field string) (Reference, error) {
+	switch field {
+	case "Before":
+		return payloadBeforeReference{rec: r.rec}, nil
+	case "After":
+		return payloadAfterReference{rec: r.rec}, nil
+	default:
+		return nil, fmt.Errorf("unexpected field %q", field)
+	}
+}
+
+type payloadBeforeReference struct {
+	rec *opencdc.Record
+}
+
+func (r payloadBeforeReference) Get() any {
+	return r.rec.Payload.Before
+}
+
+func (r payloadBeforeReference) Set(val string) error {
+	r.rec.Payload.Before = opencdc.RawData(val)
+	return nil
+}
+
+func (r payloadBeforeReference) walk(field string) (Reference, error) {
+	data, ok := r.rec.Payload.Before.(opencdc.StructuredData)
+	if !ok {
+		return nil, errors.New("payload before does not contain structured data, can't address a field inside payload before")
+	}
+	return dataFieldReference{data: data, field: field}, nil
+}
+
+type payloadAfterReference struct {
+	rec *opencdc.Record
+}
+
+func (r payloadAfterReference) Get() any {
+	return r.rec.Payload.After
+}
+
+func (r payloadAfterReference) Set(val string) error {
+	r.rec.Payload.After = opencdc.RawData(val)
+	return nil
+}
+
+func (r payloadAfterReference) walk(field string) (Reference, error) {
+	data, ok := r.rec.Payload.After.(opencdc.StructuredData)
+	if !ok {
+		return nil, errors.New("payload after does not contain structured data, can't address a field inside payload after")
+	}
+	return dataFieldReference{data: data, field: field}, nil
+}
+
+type dataFieldReference struct {
+	data  map[string]any
+	field string
+}
+
+func (r dataFieldReference) Get() any {
+	return r.data[r.field]
+}
+
+func (r dataFieldReference) Set(val string) error {
+	r.data[r.field] = val
+	return nil
+}
+
+func (r dataFieldReference) walk(field string) (Reference, error) {
+	data, ok := r.data[r.field].(map[string]any)
+	if !ok {
+		// TODO create value if it doesn't exist instead of returning an error
+		return nil, fmt.Errorf("data field %[1]s does not contain structured data, can't address a field inside %[1]s", r.field)
+	}
+	return dataFieldReference{data: data, field: field}, nil
 }

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reference
+
+import (
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/matryer/is"
+)
+
+func TestReference_Get(t *testing.T) {
+	rec := opencdc.Record{
+		Position:  opencdc.Position("foo"),
+		Operation: opencdc.OperationCreate,
+		Metadata: map[string]string{
+			"foo": "bar",
+		},
+		Key: opencdc.RawData("baz"),
+		Payload: opencdc.Change{
+			Before: opencdc.RawData("before"),
+			After:  opencdc.RawData("after"),
+		},
+	}
+
+	testCases := []struct {
+		reference string
+		want      any
+	}{
+		{".Position", rec.Position},
+		{".Operation", rec.Operation},
+		{".Metadata.foo", rec.Metadata["foo"]},
+		{".Metadata.bar", ""},
+		{".Key", rec.Key},
+		{".Payload.Before", rec.Payload.Before},
+		{".Payload.After", rec.Payload.After},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.reference, func(t *testing.T) {
+			is := is.New(t)
+			resolver, err := NewReferenceResolver(tc.reference)
+			is.NoErr(err)
+
+			ref, err := resolver.Resolve(&rec)
+			is.NoErr(err)
+
+			is.Equal(ref.Get(), tc.want)
+		})
+	}
+}
+
+func TestReference_Set(t *testing.T) {
+	testCases := []struct {
+		reference  string
+		getFieldFn func(opencdc.Record) any
+	}{
+		{".Position", func(r opencdc.Record) any { return r.Position }},
+		{".Operation", func(r opencdc.Record) any { return r.Operation }},
+		{".Metadata.foo", func(r opencdc.Record) any { return r.Metadata["foo"] }},
+		{".Metadata.bar", func(r opencdc.Record) any { return r.Metadata["bar"] }},
+		{".Key", func(r opencdc.Record) any { return r.Key }},
+		{".Payload.Before", func(r opencdc.Record) any { return r.Payload.Before }},
+		{".Payload.After", func(r opencdc.Record) any { return r.Payload.After }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.reference, func(t *testing.T) {
+			is := is.New(t)
+			resolver, err := NewReferenceResolver(tc.reference)
+			is.NoErr(err)
+
+			rec := opencdc.Record{}
+
+			ref, err := resolver.Resolve(&rec)
+			is.NoErr(err)
+
+			err = ref.Set("foo")
+			is.NoErr(err)
+
+			is.Equal(ref.Get(), tc.getFieldFn(rec))
+		})
+	}
+}

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestNewReferenceResolver_Fail(t *testing.T) {
+func TestNewResolver_Fail(t *testing.T) {
 	testCases := []string{
 		"foo",
 		"(.Key)",
@@ -38,7 +38,7 @@ func TestNewReferenceResolver_Fail(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc, func(t *testing.T) {
 			is := is.New(t)
-			_, err := NewReferenceResolver(tc)
+			_, err := NewResolver(tc)
 			is.True(err != nil)
 		})
 	}
@@ -76,7 +76,7 @@ func TestReference_Get_RawData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.reference, func(t *testing.T) {
 			is := is.New(t)
-			resolver, err := NewReferenceResolver(tc.reference)
+			resolver, err := NewResolver(tc.reference)
 			is.NoErr(err)
 
 			ref, err := resolver.Resolve(&rec)
@@ -126,7 +126,7 @@ func TestReference_Get_StructuredData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.reference, func(t *testing.T) {
 			is := is.New(t)
-			resolver, err := NewReferenceResolver(tc.reference)
+			resolver, err := NewResolver(tc.reference)
 			is.NoErr(err)
 
 			ref, err := resolver.Resolve(&rec)
@@ -159,7 +159,7 @@ func TestReference_Get_NoData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.reference, func(t *testing.T) {
 			is := is.New(t)
-			resolver, err := NewReferenceResolver(tc.reference)
+			resolver, err := NewResolver(tc.reference)
 			is.NoErr(err)
 
 			ref, err := resolver.Resolve(&rec)
@@ -176,7 +176,7 @@ type testReferenceSetCase[T any] struct {
 	wantErr bool
 }
 
-func testSet[T any](t *testing.T, resolver ReferenceResolver, tc testReferenceSetCase[T]) {
+func testSet[T any](t *testing.T, resolver Resolver, tc testReferenceSetCase[T]) {
 	is := is.New(t)
 
 	rec := opencdc.Record{}
@@ -206,7 +206,7 @@ func TestReference_Set_Position(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Position")
+	resolver, err := NewResolver(".Position")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -233,7 +233,7 @@ func TestReference_Set_Operation(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Operation")
+	resolver, err := NewResolver(".Operation")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -253,7 +253,7 @@ func TestReference_Set_Metadata(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Metadata")
+	resolver, err := NewResolver(".Metadata")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -272,7 +272,7 @@ func TestReference_Set_MetadataField(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Metadata.foo")
+	resolver, err := NewResolver(".Metadata.foo")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -291,7 +291,7 @@ func TestReference_Set_MetadataField_MapIndex(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(`.Metadata["map key with spaces and symbols @$%^&*()_+"]`)
+	resolver, err := NewResolver(`.Metadata["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -313,7 +313,7 @@ func TestReference_Set_Key(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Key")
+	resolver, err := NewResolver(".Key")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -335,7 +335,7 @@ func TestReference_Set_KeyField(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Key.foo")
+	resolver, err := NewResolver(".Key.foo")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -357,7 +357,7 @@ func TestReference_Set_KeyField_MapIndex(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(`.Key["map key with spaces and symbols @$%^&*()_+"]`)
+	resolver, err := NewResolver(`.Key["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -379,7 +379,7 @@ func TestReference_Set_PayloadBefore(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Payload.Before")
+	resolver, err := NewResolver(".Payload.Before")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -401,7 +401,7 @@ func TestReference_Set_PayloadBeforeField(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Payload.Before.foo")
+	resolver, err := NewResolver(".Payload.Before.foo")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -423,7 +423,7 @@ func TestReference_Set_PayloadBeforeField_MapIndex(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(`.Payload.Before["map key with spaces and symbols @$%^&*()_+"]`)
+	resolver, err := NewResolver(`.Payload.Before["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -445,7 +445,7 @@ func TestReference_Set_PayloadAfter(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Payload.After")
+	resolver, err := NewResolver(".Payload.After")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -467,7 +467,7 @@ func TestReference_Set_PayloadAfterField(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(".Payload.After.foo")
+	resolver, err := NewResolver(".Payload.After.foo")
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -489,7 +489,7 @@ func TestReference_Set_PayloadAfterField_MapIndex(t *testing.T) {
 	}
 
 	is := is.New(t)
-	resolver, err := NewReferenceResolver(`.Payload.After["map key with spaces and symbols @$%^&*()_+"]`)
+	resolver, err := NewResolver(`.Payload.After["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -177,7 +177,10 @@ type testReferenceSetCase[T any] struct {
 }
 
 func testSet[T any](t *testing.T, resolver Resolver, tc testReferenceSetCase[T]) {
+	t.Helper()
+
 	is := is.New(t)
+	is.Helper()
 
 	rec := opencdc.Record{}
 
@@ -222,6 +225,10 @@ func TestReference_Set_Operation(t *testing.T) {
 		{"update", opencdc.OperationUpdate, false},
 		{"delete", opencdc.OperationDelete, false},
 		{"snapshot", opencdc.OperationSnapshot, false},
+		{opencdc.OperationCreate, opencdc.OperationCreate, false},
+		{opencdc.OperationUpdate, opencdc.OperationUpdate, false},
+		{opencdc.OperationDelete, opencdc.OperationDelete, false},
+		{opencdc.OperationSnapshot, opencdc.OperationSnapshot, false},
 		{0, 0, true},
 		{1, opencdc.OperationCreate, false},
 		{2, opencdc.OperationUpdate, false},

--- a/internal/reference/reference_test.go
+++ b/internal/reference/reference_test.go
@@ -30,6 +30,9 @@ func TestNewReferenceResolver_Fail(t *testing.T) {
 		".Position.foo",
 		".Operation.foo",
 		".Metadata.foo.bar",
+		`.Metadata["foo"`,
+		`.Metadata["foo"]["bar"]`,
+		`.Metadata[]`,
 	}
 
 	for _, tc := range testCases {
@@ -279,6 +282,25 @@ func TestReference_Set_MetadataField(t *testing.T) {
 	}
 }
 
+func TestReference_Set_MetadataField_MapIndex(t *testing.T) {
+	testCases := []testReferenceSetCase[string]{
+		{"", "", false},
+		{"foo", "foo", false},
+		{nil, "", true},
+		{0, "", true},
+	}
+
+	is := is.New(t)
+	resolver, err := NewReferenceResolver(`.Metadata["map key with spaces and symbols @$%^&*()_+"]`)
+	is.NoErr(err)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.value), func(t *testing.T) {
+			testSet(t, resolver, tc)
+		})
+	}
+}
+
 func TestReference_Set_Key(t *testing.T) {
 	testCases := []testReferenceSetCase[opencdc.Data]{
 		{"", opencdc.RawData(""), false},
@@ -314,6 +336,28 @@ func TestReference_Set_KeyField(t *testing.T) {
 
 	is := is.New(t)
 	resolver, err := NewReferenceResolver(".Key.foo")
+	is.NoErr(err)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.value), func(t *testing.T) {
+			testSet(t, resolver, tc)
+		})
+	}
+}
+
+func TestReference_Set_KeyField_MapIndex(t *testing.T) {
+	testCases := []testReferenceSetCase[any]{
+		{"", "", false},
+		{"foo", "foo", false},
+		{opencdc.RawData("bar"), opencdc.RawData("bar"), false},
+		{opencdc.StructuredData{"foo": "bar"}, opencdc.StructuredData{"foo": "bar"}, false},
+		{map[string]any{"foo": "bar"}, map[string]any{"foo": "bar"}, false},
+		{nil, nil, false},
+		{0, 0, false},
+	}
+
+	is := is.New(t)
+	resolver, err := NewReferenceResolver(`.Key["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {
@@ -367,6 +411,28 @@ func TestReference_Set_PayloadBeforeField(t *testing.T) {
 	}
 }
 
+func TestReference_Set_PayloadBeforeField_MapIndex(t *testing.T) {
+	testCases := []testReferenceSetCase[any]{
+		{"", "", false},
+		{"foo", "foo", false},
+		{opencdc.RawData("bar"), opencdc.RawData("bar"), false},
+		{opencdc.StructuredData{"foo": "bar"}, opencdc.StructuredData{"foo": "bar"}, false},
+		{map[string]any{"foo": "bar"}, map[string]any{"foo": "bar"}, false},
+		{nil, nil, false},
+		{0, 0, false},
+	}
+
+	is := is.New(t)
+	resolver, err := NewReferenceResolver(`.Payload.Before["map key with spaces and symbols @$%^&*()_+"]`)
+	is.NoErr(err)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.value), func(t *testing.T) {
+			testSet(t, resolver, tc)
+		})
+	}
+}
+
 func TestReference_Set_PayloadAfter(t *testing.T) {
 	testCases := []testReferenceSetCase[opencdc.Data]{
 		{"", opencdc.RawData(""), false},
@@ -402,6 +468,28 @@ func TestReference_Set_PayloadAfterField(t *testing.T) {
 
 	is := is.New(t)
 	resolver, err := NewReferenceResolver(".Payload.After.foo")
+	is.NoErr(err)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.value), func(t *testing.T) {
+			testSet(t, resolver, tc)
+		})
+	}
+}
+
+func TestReference_Set_PayloadAfterField_MapIndex(t *testing.T) {
+	testCases := []testReferenceSetCase[any]{
+		{"", "", false},
+		{"foo", "foo", false},
+		{opencdc.RawData("bar"), opencdc.RawData("bar"), false},
+		{opencdc.StructuredData{"foo": "bar"}, opencdc.StructuredData{"foo": "bar"}, false},
+		{map[string]any{"foo": "bar"}, map[string]any{"foo": "bar"}, false},
+		{nil, nil, false},
+		{0, 0, false},
+	}
+
+	is := is.New(t)
+	resolver, err := NewReferenceResolver(`.Payload.After["map key with spaces and symbols @$%^&*()_+"]`)
 	is.NoErr(err)
 
 	for _, tc := range testCases {

--- a/util.go
+++ b/util.go
@@ -45,7 +45,8 @@ type ReferenceResolver reference.Resolver
 // field does not exist in the record, the field will be created.
 // The returned reference can be used to set the value of the field.
 func (r ReferenceResolver) Resolve(rec *opencdc.Record) (Reference, error) {
-	return reference.Resolver(r).Resolve(rec)
+	ref, err := reference.Resolver(r).Resolve(rec)
+	return Reference(ref), err
 }
 
 // NewReferenceResolver creates a new reference resolver from the input string.

--- a/util.go
+++ b/util.go
@@ -17,11 +17,52 @@ package sdk
 import (
 	"context"
 
+	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-processor-sdk/internal"
+	"github.com/conduitio/conduit-processor-sdk/internal/reference"
 	"github.com/rs/zerolog"
 )
 
+// Logger returns the logger for the current context. Please provide the context
+// that is passed to any of the processor's methods (Configure, Open, Process,
+// Teardown).
 func Logger(ctx context.Context) *zerolog.Logger {
 	// TODO if there is no util return a default logger
 	return internal.UtilFromContext(ctx).Logger(ctx)
+}
+
+// Reference is an interface that represents a reference to a field in a record.
+// It can be used to get and set the value of the field dynamically using input
+// provided by the user.
+type Reference reference.Reference
+
+// ReferenceResolver is a type that knows how to resolve a reference to a field
+// in a record. It is used to specify the target of a processor's output.
+type ReferenceResolver reference.Resolver
+
+// Resolve resolves the reference to a field in the record. If the reference
+// cannot be resolved an error is returned. If the reference is valid but the
+// field does not exist in the record, the field will be created.
+// The returned reference can be used to set the value of the field.
+func (r ReferenceResolver) Resolve(rec *opencdc.Record) (Reference, error) {
+	return reference.Resolver(r).Resolve(rec)
+}
+
+// NewReferenceResolver creates a new reference resolver from the input string.
+// The input string is a reference to a field in a record. It can be a simple
+// field name or a path to a nested field. The returned resolver can be used to
+// resolve a reference to the specified field in a record and manipulate that
+// field (get or set the value).
+//
+// Examples of valid references include:
+//   - .Position
+//   - .Operation
+//   - .Key
+//   - .Metadata.foo (to access a simple metadata value)
+//   - .Metadata["f.o.123"] (to access a metadata value via a key containing non-alpha-numeric characters)
+//   - .Payload.Before.foo (to access a nested field in payload before)
+//   - .Payload.After["1"]["2"] (to access nested fields in payload after containing non-alpha-numeric characters)
+func NewReferenceResolver(input string) (ReferenceResolver, error) {
+	resolver, err := reference.NewResolver(input)
+	return ReferenceResolver(resolver), err
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"fmt"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+)
+
+func ExampleReferenceResolver_simple() {
+	rec := opencdc.Record{
+		Position: []byte("my position"),
+	}
+
+	resolver, err := NewReferenceResolver(".Position")
+	if err != nil {
+		panic(err)
+	}
+
+	ref, err := resolver.Resolve(&rec)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("ref value:", ref.Get())
+
+	fmt.Println("setting the position is not allowed, let's try it")
+	err = ref.Set("foo")
+	fmt.Println(err)
+
+	// Output: ref value: my position
+	// setting the position is not allowed, let's try it
+	// cannot set position
+}
+
+func ExampleReferenceResolver_nested() {
+	rec := opencdc.Record{
+		Key: opencdc.StructuredData{
+			"foo": map[string]any{
+				"bar": "baz",
+			},
+		},
+	}
+
+	resolver, err := NewReferenceResolver(".Key.foo.bar")
+	if err != nil {
+		panic(err)
+	}
+
+	ref, err := resolver.Resolve(&rec)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("ref value:", ref.Get())
+
+	fmt.Println("setting the field now ...")
+	err = ref.Set("qux")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("new value:", rec.Key)
+
+	// Output: ref value: baz
+	// setting the field now ...
+	// new value: map[foo:map[bar:qux]]
+}
+
+func ExampleReferenceResolver_setNonExistingField() {
+	rec := opencdc.Record{} // empty record
+
+	resolver, err := NewReferenceResolver(".Payload.After.foo.bar")
+	if err != nil {
+		panic(err)
+	}
+
+	ref, err := resolver.Resolve(&rec)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("ref value:", ref.Get())
+
+	fmt.Println("setting the field now ...")
+	err = ref.Set("hello")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("new value:", rec.Payload.After)
+
+	// Output: ref value: <nil>
+	// setting the field now ...
+	// new value: map[foo:map[bar:hello]]
+}

--- a/util_test.go
+++ b/util_test.go
@@ -41,9 +41,10 @@ func ExampleReferenceResolver_simple() {
 	err = ref.Set("foo")
 	fmt.Println(err)
 
-	// Output: ref value: my position
+	// Output:
+	// ref value: my position
 	// setting the position is not allowed, let's try it
-	// cannot set position
+	// cannot set position: cannot set immutable reference
 }
 
 func ExampleReferenceResolver_nested() {
@@ -75,7 +76,8 @@ func ExampleReferenceResolver_nested() {
 
 	fmt.Println("new value:", rec.Key)
 
-	// Output: ref value: baz
+	// Output:
+	// ref value: baz
 	// setting the field now ...
 	// new value: map[foo:map[bar:qux]]
 }
@@ -103,7 +105,8 @@ func ExampleReferenceResolver_setNonExistingField() {
 
 	fmt.Println("new value:", rec.Payload.After)
 
-	// Output: ref value: <nil>
+	// Output:
+	// ref value: <nil>
 	// setting the field now ...
 	// new value: map[foo:map[bar:hello]]
 }

--- a/util_test.go
+++ b/util_test.go
@@ -44,7 +44,7 @@ func ExampleReferenceResolver_simple() {
 	// Output:
 	// ref value: my position
 	// setting the position is not allowed, let's try it
-	// cannot set position: cannot set immutable reference
+	// cannot set .Position: cannot set immutable reference
 }
 
 func ExampleReferenceResolver_nested() {

--- a/wasm/command.go
+++ b/wasm/command.go
@@ -26,9 +26,7 @@ import (
 
 const defaultCommandSize = 1024 // 1kB
 
-var (
-	buffer = make([]byte, defaultCommandSize)
-)
+var buffer = make([]byte, defaultCommandSize)
 
 // NextCommand retrieves the next command from Conduit.
 func NextCommand(cmdReq *processorv1.CommandRequest) error {

--- a/wasm/errors.go
+++ b/wasm/errors.go
@@ -24,21 +24,19 @@ const (
 	// The imported function _nextCommand returns an uint32 value
 	// that is either the number of bytes actually written or an error code.
 	// Because of that, we're reserving a range of error codes.
-	ErrorCodeStart = ErrorCodeNoMoreCommands
+	ErrorCodeStart = math.MaxUint32 - 100
 
-	ErrorCodeInsufficientSize = math.MaxUint32 - iota
+	ErrorCodeNoMoreCommands = math.MaxUint32 - iota
 	ErrorCodeUnknownCommandRequest
 	ErrorCodeUnknownCommandResponse
 	ErrorCodeMemoryOutOfRange
-	ErrorCodeNoMoreCommands
 )
 
 var (
-	ErrInsufficientSize       = NewError(ErrorCodeInsufficientSize, "allocated memory size is insufficient")
+	ErrNoMoreCommands         = NewError(ErrorCodeNoMoreCommands, "no more commands")
 	ErrUnknownCommandRequest  = NewError(ErrorCodeUnknownCommandRequest, "unknown command request")
 	ErrUnknownCommandResponse = NewError(ErrorCodeUnknownCommandResponse, "unknown command response")
 	ErrMemoryOutOfRange       = NewError(ErrorCodeMemoryOutOfRange, "memory out of range")
-	ErrNoMoreCommands         = NewError(ErrorCodeNoMoreCommands, "no more commands")
 )
 
 // Error is an error sent to or received from the host (i.e. Conduit).
@@ -68,16 +66,14 @@ func NewError(code uint32, message string) *Error {
 
 func NewErrorFromCode(code uint32) *Error {
 	switch code {
-	case ErrorCodeInsufficientSize:
-		return ErrInsufficientSize
+	case ErrorCodeNoMoreCommands:
+		return ErrNoMoreCommands
 	case ErrorCodeUnknownCommandRequest:
 		return ErrUnknownCommandRequest
 	case ErrorCodeUnknownCommandResponse:
 		return ErrUnknownCommandResponse
 	case ErrorCodeMemoryOutOfRange:
 		return ErrMemoryOutOfRange
-	case ErrorCodeNoMoreCommands:
-		return ErrNoMoreCommands
 	default:
 		return NewError(code, "unknown error code")
 	}

--- a/wasm/imports.go
+++ b/wasm/imports.go
@@ -25,7 +25,9 @@ import "unsafe"
 // (1) a pointer to the address where the command should be written
 // (2) the size of allocated memory.
 //
-// The return value can be 0 (for a successful reply) or an error code.
+// The return value indicates the size of the allocated request in bytes. If the
+// command is larger than the allocated memory, the caller should reallocate the
+// memory and call `command_request` again.
 //
 //go:wasmimport conduit command_request
 func _commandRequest(ptr unsafe.Pointer, size uint32) uint32


### PR DESCRIPTION
### Description

This PR contains utilities for processors when a processor needs to reference record fields dynamically based on user input. This will allow us to create processors where the user specifies the target field into which the result of the processor should be stored.

Examples of valid references:
  - `.Position`
  - `.Operation`
  - `.Key`
  - `.Metadata.foo` (to access a simple metadata value)
  - `.Metadata["f.o.123"]` (to access a metadata value via a key containing non-alpha-numeric characters)
  - `.Payload.Before.foo` (to access a nested field in payload before)
  - `.Payload.After["1"]["2"]` (to access nested fields in payload after containing non-alpha-numeric characters)

Note that the notation is the same as in Go templates (e.g. `{{ .Position }}`), and additionally it allows to reference map fields using the standard bracket notation (e.g. `.Metadata["foo"]`).

See examples in `util_test.go` to get an idea how this utility is supposed to be used.

Fixes https://github.com/ConduitIO/conduit/issues/1288

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.