### PR TITLE
Utility for simple processors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,12 @@ package sdk
 
 import "errors"
 
-// ErrUnimplemented is returned in functions of plugins that don't implement
-// a certain method.
-var ErrUnimplemented = errors.New("the processor plugin does not implement this action, please check the source code of the processor and make sure all required processor methods are implemented")
+var (
+	// ErrUnimplemented is returned in functions of plugins that don't implement
+	// a certain method.
+	ErrUnimplemented = errors.New("the processor plugin does not implement " +
+		"this action, please check the source code of the processor and make sure " +
+		"all required processor methods are implemented")
+
+	ErrFilterRecord = errors.New("filter out this record")
+)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bufbuild/buf v1.29.0
 	github.com/conduitio/conduit-commons v0.0.0-20240103200651-5a5746611a8e
 	github.com/golangci/golangci-lint v1.55.2
+	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.32.0
 	go.uber.org/mock v0.4.0
 	google.golang.org/protobuf v1.32.0

--- a/processor_func.go
+++ b/processor_func.go
@@ -1,0 +1,68 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"errors"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+)
+
+// ProcessorFunc is an adapter allowing use of a function as a Processor.
+type ProcessorFunc struct {
+	UnimplementedProcessor
+
+	specs Specification
+	f     func(context.Context, opencdc.Record) (opencdc.Record, error)
+}
+
+var _ Processor = ProcessorFunc{} // Ensure ProcessorFunc implements Processor
+
+// NewProcessorFunc creates a ProcessorFunc from a function and specifications.
+// This is useful for creating simple processors without needing to implement
+// the full Processor interface.
+func NewProcessorFunc(specs Specification, f func(context.Context, opencdc.Record) (opencdc.Record, error)) ProcessorFunc {
+	return ProcessorFunc{
+		specs: specs,
+		f:     f,
+	}
+}
+
+func (f ProcessorFunc) Specification() (Specification, error)            { return f.specs, nil }
+func (ProcessorFunc) Configure(context.Context, map[string]string) error { return nil }
+func (ProcessorFunc) Open(context.Context) error {
+	return nil
+}
+
+func (f ProcessorFunc) Process(ctx context.Context, records []opencdc.Record) []ProcessedRecord {
+	outRecs := make([]ProcessedRecord, len(records))
+	for i, inRec := range records {
+		outRec, err := f.f(ctx, inRec)
+		switch {
+		case errors.Is(err, ErrFilterRecord):
+			outRecs[i] = FilterRecord{}
+		case err != nil:
+			outRecs[i] = ErrorRecord{Error: err}
+		default:
+			outRecs[i] = SingleRecord(outRec)
+		}
+	}
+	return outRecs
+}
+
+func (ProcessorFunc) Teardown(context.Context) error {
+	return nil
+}

--- a/processor_func.go
+++ b/processor_func.go
@@ -56,6 +56,7 @@ func (f ProcessorFunc) Process(ctx context.Context, records []opencdc.Record) []
 			outRecs[i] = FilterRecord{}
 		case err != nil:
 			outRecs[i] = ErrorRecord{Error: err}
+			return outRecs[:i+1] // stop processing on first error
 		default:
 			outRecs[i] = SingleRecord(outRec)
 		}

--- a/processor_func_test.go
+++ b/processor_func_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/matryer/is"
+)
+
+func TestProcessorFunc_Process_Success(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	proc := NewProcessorFunc(
+		Specification{Name: "test"},
+		func(ctx context.Context, record opencdc.Record) (opencdc.Record, error) {
+			record.Metadata = opencdc.Metadata{"foo": "bar"}
+			return record, nil
+		},
+	)
+
+	// process 2 records
+	processedRecords := proc.Process(ctx, []opencdc.Record{{}, {}})
+
+	is.Equal(len(processedRecords), 2)
+	for _, rec := range processedRecords {
+		got, ok := rec.(SingleRecord)
+		is.True(ok)
+		is.Equal(got.Metadata, opencdc.Metadata{"foo": "bar"})
+	}
+}
+
+func TestProcessorFunc_Process_Error(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	wantErr := errors.New("test error")
+
+	proc := NewProcessorFunc(
+		Specification{Name: "test"},
+		func(ctx context.Context, record opencdc.Record) (opencdc.Record, error) {
+			return opencdc.Record{}, wantErr
+		},
+	)
+
+	// process 2 records
+	processedRecords := proc.Process(ctx, []opencdc.Record{{}, {}})
+
+	is.Equal(len(processedRecords), 1)
+	gotErr, ok := processedRecords[0].(ErrorRecord)
+	is.True(ok)
+	is.Equal(gotErr.Error, wantErr)
+}


### PR DESCRIPTION
### Description

This creates `ProcessorFunc` which is a utility for creating simple processors without having to implement the whole interface.

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [x] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.