### PR TITLE
Add utility method ParseConfig

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -39,5 +39,13 @@ func UtilFromContext(ctx context.Context) Util {
 	if util != nil {
 		return util.(Util) //nolint:forcetypeassert // we know it's a Util, we set it
 	}
-	return nil
+	return DefaultUtil{}
+}
+
+// DefaultUtil is the default implementation of Util. This is used when no Util
+// is set (i.e. in tests).
+type DefaultUtil struct{}
+
+func (DefaultUtil) Logger(ctx context.Context) *zerolog.Logger {
+	return zerolog.Ctx(ctx)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -15,8 +15,11 @@
 package sdk
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
 )
 
@@ -109,4 +112,32 @@ func ExampleReferenceResolver_setNonExistingField() {
 	// ref value: <nil>
 	// setting the field now ...
 	// new value: map[foo:map[bar:hello]]
+}
+
+func ExampleParseConfig() {
+	cfg := map[string]string{
+		"foo":        "bar",
+		"nested.baz": "1m",
+	}
+
+	params := config.Parameters{
+		"foo":        config.Parameter{Type: config.ParameterTypeString},
+		"nested.baz": config.Parameter{Type: config.ParameterTypeDuration},
+	}
+
+	var target struct {
+		Foo    string `json:"foo"`
+		Nested struct {
+			Baz time.Duration `json:"baz"`
+		} `json:"nested"`
+	}
+
+	err := ParseConfig(context.Background(), cfg, &target, params)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", target)
+
+	// Output: {Foo:bar Nested:{Baz:1m0s}}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -116,17 +116,23 @@ func ExampleReferenceResolver_setNonExistingField() {
 
 func ExampleParseConfig() {
 	cfg := map[string]string{
-		"foo":        "bar",
+		"foo": "bar   ", // will be sanitized
+		// "bar" is missing, will be set to the default value
 		"nested.baz": "1m",
 	}
 
 	params := config.Parameters{
-		"foo":        config.Parameter{Type: config.ParameterTypeString},
+		"foo": config.Parameter{Type: config.ParameterTypeString},
+		"bar": config.Parameter{
+			Type:    config.ParameterTypeInt,
+			Default: "42",
+		},
 		"nested.baz": config.Parameter{Type: config.ParameterTypeDuration},
 	}
 
 	var target struct {
 		Foo    string `json:"foo"`
+		Bar    int    `json:"bar"`
 		Nested struct {
 			Baz time.Duration `json:"baz"`
 		} `json:"nested"`
@@ -139,5 +145,5 @@ func ExampleParseConfig() {
 
 	fmt.Printf("%+v", target)
 
-	// Output: {Foo:bar Nested:{Baz:1m0s}}
+	// Output: {Foo:bar Bar:42 Nested:{Baz:1m0s}}
 }


### PR DESCRIPTION
### Description

Adds a convenience method for parsing the config.

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [X] I have written unit tests. (well, example)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.