### PR TITLE
Add json tags to processor specification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.5
 
 require (
 	github.com/bufbuild/buf v1.29.0
-	github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a
+	github.com/conduitio/conduit-commons v0.0.0-20240229142452-df003dec114a
 	github.com/golangci/golangci-lint v1.56.2
 	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.5
 
 require (
 	github.com/bufbuild/buf v1.29.0
-	github.com/conduitio/conduit-commons v0.0.0-20240216175021-58737e44eb62
+	github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a
 	github.com/golangci/golangci-lint v1.56.2
 	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conduitio/conduit-commons v0.0.0-20240216175021-58737e44eb62 h1:h1AcneviaadJqw1KAUfzIDBVrODma4rneg13q726KQU=
 github.com/conduitio/conduit-commons v0.0.0-20240216175021-58737e44eb62/go.mod h1:Hhr5nik71/Wz3yrLjaKSZ2HRQp1wNSOPY2JGGKz7fsw=
+github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a h1:Zpw3wFuvx8lgr+cMjYz9yPweEC/VXIlFd+wxrD1s7Tg=
+github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a/go.mod h1:Hhr5nik71/Wz3yrLjaKSZ2HRQp1wNSOPY2JGGKz7fsw=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=

--- a/go.sum
+++ b/go.sum
@@ -135,10 +135,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/conduitio/conduit-commons v0.0.0-20240216175021-58737e44eb62 h1:h1AcneviaadJqw1KAUfzIDBVrODma4rneg13q726KQU=
-github.com/conduitio/conduit-commons v0.0.0-20240216175021-58737e44eb62/go.mod h1:Hhr5nik71/Wz3yrLjaKSZ2HRQp1wNSOPY2JGGKz7fsw=
-github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a h1:Zpw3wFuvx8lgr+cMjYz9yPweEC/VXIlFd+wxrD1s7Tg=
-github.com/conduitio/conduit-commons v0.0.0-20240229141546-e5b020b6d35a/go.mod h1:Hhr5nik71/Wz3yrLjaKSZ2HRQp1wNSOPY2JGGKz7fsw=
+github.com/conduitio/conduit-commons v0.0.0-20240229142452-df003dec114a h1:sYqOLuHKthGfpQHNmiXP4c6cYl9JRFfcDGB8Mahm1E0=
+github.com/conduitio/conduit-commons v0.0.0-20240229142452-df003dec114a/go.mod h1:Hhr5nik71/Wz3yrLjaKSZ2HRQp1wNSOPY2JGGKz7fsw=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=

--- a/processor.go
+++ b/processor.go
@@ -62,19 +62,19 @@ type Processor interface {
 // and allows them to describe their parameters.
 type Specification struct {
 	// Name is the name of the processor.
-	Name string
+	Name string `json:"name"`
 	// Summary is a brief description of the processor and what it does.
-	Summary string
+	Summary string `json:"summary"`
 	// Description is a more long form area appropriate for README-like text
 	// that the author can provide for documentation about the specified
 	// Parameters.
-	Description string
+	Description string `json:"description"`
 	// Version string. Should be a semver prepended with `v`, e.g. `v1.54.3`.
-	Version string
+	Version string `json:"version"`
 	// Author declares the entity that created or maintains this processor.
-	Author string
+	Author string `json:"author"`
 	// Parameters describe how to configure the processor.
-	Parameters config.Parameters
+	Parameters config.Parameters `json:"parameters"`
 }
 
 // ProcessedRecord is a record returned by the processor.


### PR DESCRIPTION
### Description

Together with https://github.com/ConduitIO/conduit-commons/pull/24 this ensures that processor specifications are marshaled into a nice JSON structure (lowercase fields). Relevant for exporting processor specification for documentation purposes.

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.