### PR TITLE
Readme + Processor simplification

### DIFF
--- a/processor_func.go
+++ b/processor_func.go
@@ -41,11 +41,7 @@ func NewProcessorFunc(specs Specification, f func(context.Context, opencdc.Recor
 	}
 }
 
-func (f ProcessorFunc) Specification() (Specification, error)            { return f.specs, nil }
-func (ProcessorFunc) Configure(context.Context, map[string]string) error { return nil }
-func (ProcessorFunc) Open(context.Context) error {
-	return nil
-}
+func (f ProcessorFunc) Specification() (Specification, error) { return f.specs, nil }
 
 func (f ProcessorFunc) Process(ctx context.Context, records []opencdc.Record) []ProcessedRecord {
 	outRecs := make([]ProcessedRecord, len(records))
@@ -62,8 +58,4 @@ func (f ProcessorFunc) Process(ctx context.Context, records []opencdc.Record) []
 		}
 	}
 	return outRecs
-}
-
-func (ProcessorFunc) Teardown(context.Context) error {
-	return nil
 }

--- a/unimplemented.go
+++ b/unimplemented.go
@@ -29,24 +29,24 @@ func (UnimplementedProcessor) Specification() (Specification, error) {
 	return Specification{}, fmt.Errorf("action \"Specification\": %w", ErrUnimplemented)
 }
 
-// Configure needs to be overridden in the actual implementation.
+// Configure is optional and can be overridden in the actual implementation.
 func (UnimplementedProcessor) Configure(context.Context, map[string]string) error {
-	return fmt.Errorf("action \"Configure\": %w", ErrUnimplemented)
+	return nil
 }
 
-// Open needs to be overridden in the actual implementation.
+// Open is optional and can be overridden in the actual implementation.
 func (UnimplementedProcessor) Open(context.Context) error {
-	return fmt.Errorf("action \"Open\": %w", ErrUnimplemented)
+	return nil
 }
 
 // Process needs to be overridden in the actual implementation.
 func (UnimplementedProcessor) Process(context.Context, []opencdc.Record) []ProcessedRecord {
-	return nil
+	return []ProcessedRecord{ErrorRecord{Error: ErrUnimplemented}}
 }
 
-// Teardown needs to be overridden in the actual implementation.
+// Teardown is optional and can be overridden in the actual implementation.
 func (UnimplementedProcessor) Teardown(context.Context) error {
-	return fmt.Errorf("action \"Teardown\": %w", ErrUnimplemented)
+	return nil
 }
 
 func (UnimplementedProcessor) mustEmbedUnimplementedProcessor() {}


### PR DESCRIPTION
### Description

This PR contains the updated readme and a simplification, where processor implementations do not actually have to implement `Configure`, `Open` and `Teardown`, if they don't have a use for these functions (all our builtin processors for example). This results in fewer boilerplate code.

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.