### PR TITLE
Fixes for simple-processor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import (
 
 func main() {
    sdk.Run(sdk.NewProcessorFunc(
-      sdk.Specification{Name: "simple-processor", Version: "v1.0.0"},
+      sdk.Specification{Name: "simple-processor"},
       func(ctx context.Context, rec opencdc.Record) (opencdc.Record, error) {
          // do something with the record
          return rec, nil

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func main() {
 }
 ```
 
-If the processor is very simple and can be reduced to a single function (e.g. 
+If the processor is very simple and can be reduced to a single function (e.g.
 no configuration needed), then we can use `sdk.NewProcessorFunc()`, as below:
 
 ```go
@@ -112,13 +112,13 @@ import (
 )
 
 func main() {
-   sdk.Run(&sdk.NewProcessorFunc(
-      sdk.Specification{Name: "simple-processor"}),
+   sdk.Run(sdk.NewProcessorFunc(
+      sdk.Specification{Name: "simple-processor", Version: "v1.0.0"},
       func(ctx context.Context, rec opencdc.Record) (opencdc.Record, error) {
          // do something with the record
-         return rec
+         return rec, nil
       },
-   )
+   ))
 }
 ```
 


### PR DESCRIPTION
### Description

This change fixes the simple-processor example in the README. That example has a few issues that would cause the code to not compile and the processor from being successfully loaded by Conduit.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [ ] I have written unit tests. (n/a)
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.