### PR TITLE
Add custom json marshalling to ErrorRecord

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,6 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
     - exportloopref
     # - forbidigo
@@ -75,7 +74,7 @@ linters:
     - goconst
     - gocritic
     - godot
-    - goerr113
+    - err113
     - gofmt
     - gofumpt
     - goheader

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ toolchain go1.21.5
 require (
 	github.com/bufbuild/buf v1.31.0
 	github.com/conduitio/conduit-commons v0.2.0
+	github.com/goccy/go-json v0.10.2
 	github.com/golangci/golangci-lint v1.58.1
+	github.com/google/go-cmp v0.6.0
 	github.com/matryer/is v1.4.1
 	github.com/rs/zerolog v1.32.0
 	go.uber.org/mock v0.4.0
@@ -94,7 +96,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -107,7 +108,6 @@ require (
 	github.com/golangci/revgrep v0.5.3 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect
 	github.com/google/cel-go v0.20.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-containerregistry v0.19.1 // indirect
 	github.com/google/pprof v0.0.0-20240422182052-72c8669ad3e7 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect

--- a/processor.go
+++ b/processor.go
@@ -16,6 +16,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
@@ -95,10 +96,22 @@ func (FilterRecord) isProcessedRecord() {}
 // ErrorRecord is a record that failed to be processed and will be nacked.
 type ErrorRecord struct {
 	// Error is the error cause.
-	Error error
+	Error error `json:"error"`
 }
 
 func (e ErrorRecord) isProcessedRecord() {}
+func (e ErrorRecord) MarshalJSON() ([]byte, error) {
+	var errorMsg string
+	if e.Error != nil {
+		errorMsg = e.Error.Error()
+	}
+	anon := struct {
+		Error string `json:"error"`
+	}{
+		Error: errorMsg,
+	}
+	return json.Marshal(anon)
+}
 
 // Support for MultiRecord will be added in the future.
 // type MultiRecord []opencdc.Record

--- a/processor.go
+++ b/processor.go
@@ -110,7 +110,7 @@ func (e ErrorRecord) MarshalJSON() ([]byte, error) {
 	}{
 		Error: errorMsg,
 	}
-	return json.Marshal(anon)
+	return json.Marshal(anon) //nolint:wrapcheck // no need to wrap error
 }
 
 // Support for MultiRecord will be added in the future.

--- a/processor_test.go
+++ b/processor_test.go
@@ -1,0 +1,95 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/goccy/go-json"
+	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
+)
+
+func TestProcessedRecord_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		have ProcessedRecord
+		want string
+	}{{
+		name: "SingleRecord",
+		have: SingleRecord{
+			Operation: opencdc.OperationCreate,
+			Position:  opencdc.Position("test-position"),
+			Metadata:  opencdc.Metadata{"foo": "bar"},
+			Key:       opencdc.RawData("test-key"),
+			Payload: opencdc.Change{
+				Before: opencdc.StructuredData{"foo": "before"},
+				After:  opencdc.StructuredData{"foo": "after"},
+			},
+		},
+		want: `{
+  "position": "dGVzdC1wb3NpdGlvbg==",
+  "operation": "create",
+  "metadata": {
+    "foo": "bar"
+  },
+  "key": "test-key",
+  "payload": {
+    "before": {
+      "foo": "before"
+    },
+    "after": {
+      "foo": "after"
+    }
+  }
+}`,
+	}, {
+		name: "FilterRecord",
+		have: FilterRecord{},
+		want: `{}`,
+	}, {
+		name: "ErrorRecord",
+		have: ErrorRecord{
+			Error: errors.New("error"),
+		},
+		want: `{
+  "error": "error"
+}`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			ctx := context.Background()
+
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			enc.SetIndent("", "  ")
+
+			ctx = opencdc.WithJSONMarshalOptions(ctx, &opencdc.JSONMarshalOptions{RawDataAsString: true})
+			err := enc.EncodeContext(ctx, tc.have)
+			is.NoErr(err)
+
+			got := buf.String()
+			got = got[:len(got)-1] // remove trailing newline
+			is.Equal("", cmp.Diff(tc.want, got))
+		})
+
+	}
+}

--- a/processor_test.go
+++ b/processor_test.go
@@ -90,6 +90,5 @@ func TestProcessedRecord_MarshalJSON(t *testing.T) {
 			got = got[:len(got)-1] // remove trailing newline
 			is.Equal("", cmp.Diff(tc.want, got))
 		})
-
 	}
 }


### PR DESCRIPTION
### Description

When adding the [error processor](https://github.com/ConduitIO/conduit/pull/1598) I noticed that an `ErrorRecord` is not marshalled correctly into JSON. This PR adds a custom marshalling function and accompanying tests.

### Quick checks:

- [X] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.