### PR TITLE
Fix parsing of SDK parameters

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -178,17 +178,14 @@ func (p *processorWithSchemaDecode) Specification() (Specification, error) {
 }
 
 func (p *processorWithSchemaDecode) Configure(ctx context.Context, config config.Config) error {
-	err := p.Processor.Configure(ctx, config)
-	if err != nil {
-		return err //nolint:wrapcheck // middleware shouldn't wrap errors
-	}
-
+	var err error
 	p.keyEnabled = *p.defaults.KeyEnabled
 	if val, ok := config[configProcessorWithSchemaDecodeKeyEnabled]; ok {
 		p.keyEnabled, err = strconv.ParseBool(val)
 		if err != nil {
 			return fmt.Errorf("invalid %s: failed to parse boolean: %w", configProcessorWithSchemaDecodeKeyEnabled, err)
 		}
+		delete(config, configProcessorWithSchemaDecodeKeyEnabled)
 	}
 
 	p.payloadEnabled = *p.defaults.PayloadEnabled
@@ -197,9 +194,10 @@ func (p *processorWithSchemaDecode) Configure(ctx context.Context, config config
 		if err != nil {
 			return fmt.Errorf("invalid %s: failed to parse boolean: %w", configProcessorWithSchemaDecodePayloadEnabled, err)
 		}
+		delete(config, configProcessorWithSchemaDecodePayloadEnabled)
 	}
 
-	return nil
+	return p.Processor.Configure(ctx, config)
 }
 
 func (p *processorWithSchemaDecode) Process(ctx context.Context, records []opencdc.Record) []ProcessedRecord {
@@ -414,11 +412,7 @@ func (p *processorWithSchemaEncode) Specification() (Specification, error) {
 }
 
 func (p *processorWithSchemaEncode) Configure(ctx context.Context, config config.Config) error {
-	err := p.Processor.Configure(ctx, config)
-	if err != nil {
-		return err //nolint:wrapcheck // middleware shouldn't wrap errors
-	}
-
+	var err error
 	encodeKey := *p.defaults.KeyEnabled
 	if val, ok := config[configProcessorSchemaEncodeKeyEnabled]; ok {
 		encodeKey, err = strconv.ParseBool(val)
@@ -438,7 +432,7 @@ func (p *processorWithSchemaEncode) Configure(ctx context.Context, config config
 	p.keyEnabled = encodeKey
 	p.payloadEnabled = encodePayload
 
-	return nil
+	return p.Processor.Configure(ctx, config)
 }
 
 type subjectVersion struct {


### PR DESCRIPTION
### Description

Fixes https://github.com/ConduitIO/conduit/issues/2185.

**The problem**:

Processors are parsing configurations with code like this:

```go
// example from the field.set processor
sdk.ParseConfig(ctx, c, &cfg, setConfig{}.Parameters())
```
`setConfig` doesn't have the SDK parameters, so parsing fails.

**The solution**

There are 3 possible solutions:

1. Remove the SDK parameters before they reach the processor's  `Configure` method. The middleware parses and removes any SDK configuration.
2. Add the SDK parameters to `setConfig` (e.g., by embedding an SDK middleware config struct, similar to what we have in the connector SDK).
  - This requires a new SDK middleware config to be added and the SDK needs to inspect a processor's config to figure out which middleware needs to be applied.
3. Don't change the config struct, but change the processor's specification to include the SDK parameters too.
  - This means that all processor constructors need to be changed to wrap the processor into middleware and return an `sdk.Processor` interface.
  - Also, the `Configure` method needs to change to take the parameters from the processor's specification.

No. 2 is something we did in the connector, and it was a useful refactoring, but required a number of changes. 

No. 3 changes all processor constructors, `Configure` methods and also some tests that rely on a processor's fields.

On the other hand, 2 and 3 are useful to make processor middleware and configuration more flexible in future.

However, given that we do not plan something like that in near future, the additional work for 2 and 3 aren't worth it, which is no. 1 is implemented in this PR.
 

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio/conduit-processor-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.